### PR TITLE
fix: Removing Widget's aliasing

### DIFF
--- a/app/instancepanel.cpp
+++ b/app/instancepanel.cpp
@@ -84,7 +84,6 @@ void InstancePanelCell::startDrag(const QPoint &pos)
     mimeData->setData(MoveMimeDataFormat, itemData);
 
     QPixmap pixmap(child->grab());
-    pixmap.setMask(WidgetContainer::bitmapOfMask(pixmap.size(), m_instance->isUserAreaInstance()));
 
     QDrag *drag = new QDrag(this);
     drag->setMimeData(mimeData);
@@ -454,7 +453,6 @@ void InstancePanel::onMenuRequested(const InstanceId &id)
             auto logo = plugin->logo();
             if(logo.isNull()) {
                 QPixmap pixmap(instance->view()->grab());
-                pixmap.setMask(WidgetContainer::bitmapOfMask(pixmap.size(), instance->isUserAreaInstance()));
                 logo = QIcon(pixmap);
             }
             dialog.setLogo(logo);

--- a/app/instanceproxy.h
+++ b/app/instanceproxy.h
@@ -9,23 +9,37 @@
 #include <QPointer>
 #include <QWidget>
 #include <widgetsinterface.h>
+#include <DWidget>
+
+DWIDGET_BEGIN_NAMESPACE
+class DClipEffectWidget;
+DWIDGET_END_NAMESPACE
 
 WIDGETS_FRAME_BEGIN_NAMESPACE
 WIDGETS_USE_NAMESPACE
 class WidgetContainer : public QWidget {
     Q_OBJECT
 public:
-    explicit WidgetContainer(QWidget *view, QWidget *parent = nullptr);
+    explicit WidgetContainer(QWidget *view, bool isCustom, QWidget *parent = nullptr);
     virtual ~WidgetContainer() override;
     void setIsUserAreaInstance(const bool isUserAreaInstance);
 
-    static QBitmap bitmapOfMask(const QSize &size, const bool isUserAreaInstance);
-    static QBitmap bitmapOfMask(const QSize &size, const qreal radius);
-
+    static QPainterPath clipPathOfRound(const QRect &rect, const bool isUserAreaInstance);
 protected:
     virtual void resizeEvent(QResizeEvent *event) override;
     bool m_isUserAreaInstance = false;
     QPointer<QWidget> m_view = nullptr;
+    DTK_WIDGET_NAMESPACE::DClipEffectWidget *m_clipView = nullptr;
+};
+
+class PlaceholderWidget : public QWidget {
+    Q_OBJECT
+public:
+    PlaceholderWidget(QWidget *view, QWidget *parent = nullptr);
+protected:
+    virtual void paintEvent(QPaintEvent *event) override;
+private:
+    QWidget *m_view = nullptr;
 };
 
 class InstanceProxy : public QObject {

--- a/app/widgetstore.cpp
+++ b/app/widgetstore.cpp
@@ -23,6 +23,7 @@
 #include <DAnchors>
 #include <DFontSizeManager>
 #include <DButtonBox>
+#include <DClipEffectWidget>
 
 WIDGETS_FRAME_BEGIN_NAMESPACE
 WidgetStore::WidgetStore(WidgetManager *manager, QWidget *parent)
@@ -242,7 +243,7 @@ void WidgetStoreCell::setView(QWidget *view)
     m_view->resize(m_handler->size());
     const auto &targetSize = WidgetHandlerImpl::size(m_handler->type(), false);
 
-    m_viewPlaceholder = new QLabel(this);
+    m_viewPlaceholder = new PlaceholderWidget(m_view, this);
     m_viewPlaceholder->resize(targetSize);
 
     auto action = new DIconButton(DStyle::SP_AddButton);
@@ -275,7 +276,7 @@ QWidget *WidgetStoreCell::action() const
 
 void WidgetStoreCell::startDrag(const QPoint &pos)
 {
-    QWidget *child = m_view;
+    QWidget *child = m_viewPlaceholder;
     if (!child)
         return;
 
@@ -290,7 +291,6 @@ void WidgetStoreCell::startDrag(const QPoint &pos)
     mimeData->setData(EditModeMimeDataFormat, itemData);
 
     QPixmap pixmap(child->grab());
-    pixmap.setMask(WidgetContainer::bitmapOfMask(pixmap.size(), WidgetHandlerImpl::get(m_handler)->m_isUserAreaInstance));
 
     QDrag *drag = new QDrag(this);
     drag->setMimeData(mimeData);
@@ -360,12 +360,6 @@ void WidgetStoreCell::updateViewPlaceholder()
 {
     if (!m_viewPlaceholder)
         return;
-
-    const auto &targetSize = m_viewPlaceholder->size();
-    QPixmap pixmap = m_view->grab();
-    pixmap = pixmap.scaled(targetSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-    pixmap.setMask(WidgetContainer::bitmapOfMask(pixmap.size(), WidgetHandlerImpl::get(m_handler)->m_isUserAreaInstance));
-    m_viewPlaceholder->setPixmap(pixmap);
 
     update();
 }

--- a/app/widgetstore.h
+++ b/app/widgetstore.h
@@ -22,6 +22,7 @@ DWIDGET_END_NAMESPACE
 WIDGETS_FRAME_BEGIN_NAMESPACE
 class WidgetManager;
 class WidgetStoreCell;
+class PlaceholderWidget;
 class PluginCell : public DBlurEffectWidget {
     Q_OBJECT
 public:
@@ -69,7 +70,7 @@ private:
     void updateViewPlaceholder();
 
     QWidget *m_view = nullptr;
-    QLabel *m_viewPlaceholder = nullptr;
+    PlaceholderWidget *m_viewPlaceholder = nullptr;
     QBasicTimer m_viewPlaceholderFresher;
     QWidget *m_action = nullptr;
 };


### PR DESCRIPTION
  We add radius for each Widget in fram instead of plugin.
Before, we impliment it through `setMask`, but aliasing is unavoidable.
Now, we use `DClipEffectWidget` to clip view radius for `custom` type plugin, and for PluginStore's widget, we paint a pixmap grabed origin widget in `PlaceholderWidget`.

Issue: https://github.com/linuxdeepin/dde-widgets/issues/18