### PR TITLE
fix: 修复玲珑应用通知无法跳转

### DIFF
--- a/notification/notification/bubbletool.cpp
+++ b/notification/notification/bubbletool.cpp
@@ -13,8 +13,11 @@
 #include <QX11Info>
 #include <QSettings>
 #include <QTextCodec>
+#include <QDBusConnection>
+#include <QDBusMessage>
 
 #include <DDesktopEntry>
+#include <DStandardPaths>
 
 DCORE_USE_NAMESPACE
 
@@ -188,6 +191,21 @@ const QString BubbleTool::getDeepinAppName(const QString &name)
     return desktop.localizedValue("Name", localKey, "Desktop Entry", name);
 }
 
+const QString BubbleTool::getDeepinDesktopPath(const QString &name)
+{
+    QString desktopPath;
+
+    for (const auto dataPath : DStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation)) {
+        auto path = QStringList{ dataPath, QString("%1.desktop").arg(name)}.join(QDir::separator()));
+            if (QFile::exists(path)) {
+                desktopPath = path;
+                break;
+            }
+    }
+
+    return desktopPath;
+}
+
 void BubbleTool::actionInvoke(const QString &actionId, EntityPtr entity)
 {
     qDebug() << "actionId:" << actionId;
@@ -196,10 +214,17 @@ void BubbleTool::actionInvoke(const QString &actionId, EntityPtr entity)
     while (i != hints.constEnd()) {
         QStringList args = i.value().toString().split(",");
         if (!args.isEmpty()) {
-            QString cmd = args.first(); //命令
+            QString appName = args.first(); //命令
+            auto desktopPath = getDeepinDesktopPath(appName);
             args.removeFirst();
             if (i.key() == "x-deepin-action-" + actionId) {
-                QProcess::startDetached(cmd, args); //执行相关命令
+                QDBusConnection conn = QDBusConnection::sessionBus();
+                QDBusMessage msg = QDBusMessage::createMethodCall("org.deepin.dde.StartManager1",
+                                                        "/org/deepin/dde/StartManager1",
+                                                        "org.deepin.dde.StartManager1",
+                                                        "LaunchApp");
+                msg << desktopPath << 0 << args;
+                conn.sessionBus().call(msg, QDBus::NoBlock);
             }
         }
         ++i;

--- a/notification/notification/bubbletool.h
+++ b/notification/notification/bubbletool.h
@@ -25,6 +25,7 @@ public:
     static void processIconData(AppIcon *icon, EntityPtr entity); //从entity提取出图标信息设置到icon上
     static void actionInvoke(const QString &actionId, EntityPtr entity);//从entity提取出命令信息,执行命令产生相应动作
     static const QString getDeepinAppName(const QString &name);//获取应用名称
+    static const QString getDeepinDesktopPath(const QString &name);//获取desktop文件路径
 
 private:
     /*!


### PR DESCRIPTION
通过应用对应desktop文件启动应用
close linuxdeepin/developer-center#3657