### PR TITLE
fix: incorrect widget and notification center alignment

### DIFF
--- a/app/displaymodepanel.cpp
+++ b/app/displaymodepanel.cpp
@@ -40,7 +40,7 @@ void DisplayModePanel::init()
     auto layout = new QVBoxLayout(this);
     layout->setContentsMargins(UI::defaultMargins);
     layout->setSpacing(0);
-    m_views->setFixedWidth(width());
+    m_views->setFixedWidth(width() - 10);
 
     layout->addWidget(m_views);
 

--- a/app/instancepanel.cpp
+++ b/app/instancepanel.cpp
@@ -109,8 +109,8 @@ InstancePanel::InstancePanel(WidgetManager *manager, QWidget *parent)
     pt.setColor(QPalette::Window, Qt::transparent);
     setPalette(pt);
     setAutoFillBackground(true);
-    m_layout->setContentsMargins(UI::defaultMargins);
-    m_layout->setSpacing(UI::Ins::spacing);
+    m_layout->setContentsMargins(QMargins(10, 0, 0, 0));
+    m_layout->setSpacing(UI::Ins::spacing - 10);
 
     // TODO DFlowLayout seems to have the smallest size, it causes extra space even though add stretch.
     // and it's ok replaced `QVBoxLayout`, it maybe a `DFlowLayout` bug.

--- a/app/mainview.cpp
+++ b/app/mainview.cpp
@@ -27,9 +27,9 @@ MainView::MainView( WidgetManager *manager, QWidget *parent)
     , m_geometryHandler(new GeometryHandler())
     , m_appearancehandler(new Appearancehandler(this))
 {
-    // TODO DBlurEffectWidget is black when changing BlurEnabled but none Composite, it's maybe a bug.
-    // But we can not consider this scene.
-    setBlurEnabled(false);
+//    // TODO DBlurEffectWidget is black when changing BlurEnabled but none Composite, it's maybe a bug.
+//    // But we can not consider this scene.
+//    setBlurEnabled(false);
 
     setParent(m_animationContainer);
     m_appearancehandler->addTargetWidget(m_animationContainer);

--- a/app/widgetstore.cpp
+++ b/app/widgetstore.cpp
@@ -32,6 +32,7 @@ WidgetStore::WidgetStore(WidgetManager *manager, QWidget *parent)
     , m_views(new QWidget(this))
     , m_layout(new QVBoxLayout(m_views))
 {
+    m_layout->setContentsMargins(UI::Store::leftMargin, 0, UI::Store::rightMargin, 0);
     m_layout->setSpacing(UI::Store::spacing);
 
     QPalette pt = palette();

--- a/notification/notifycenterwidget.cpp
+++ b/notification/notifycenterwidget.cpp
@@ -114,7 +114,7 @@ void NotifyCenterWidget::initUI()
     connect(m_notifyWidget->view(), &NotifyListView::lastItemCreated, this, &NotifyCenterWidget::updateTabFocus);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
-    mainLayout->setContentsMargins(Notify::CenterMargin, Notify::CenterMargin, 0, 0);
+    mainLayout->setContentsMargins(0, Notify::CenterMargin, 0, 0);
     mainLayout->addWidget(m_headWidget);
     mainLayout->addWidget(m_notifyWidget);
     mainLayout->addWidget(bottomTipView, 0, Qt::AlignHCenter);


### PR DESCRIPTION
修正小部件与通知中心对不齐的问题

左侧的空白是一律留出的，所以这里的空白不应当由通知中心插件来做。当然此 patch 做的修正只是解决了视觉上的对齐问题，仍然建议重新梳理和调整相关的布局方式。

Resolve https://github.com/linuxdeepin/dde-widgets/issues/15