### PR TITLE
fix: incorrect widget background

### DIFF
--- a/memorymonitor/memorywidget.cpp
+++ b/memorymonitor/memorywidget.cpp
@@ -7,6 +7,7 @@
 
 #include <DApplication>
 #include <DApplicationHelper>
+#include <DPaletteHelper>
 
 #include <QApplication>
 #include <QDebug>
@@ -59,14 +60,16 @@ void MemoryWidget::changeTheme(DApplicationHelper::ColorType themeType)
     }
 
     // init colors
-    auto palette = DApplicationHelper::instance()->applicationPalette();
+    auto palette = DPaletteHelper::instance()->palette(this);
 #ifndef THEME_FALLBACK_COLOR
-    numberColor = palette.color(DPalette::TextTitle);
+    numberColor = palette.color(QPalette::BrightText); // was DPalette::TextTitle
 #else
     numberColor = palette.color(DPalette::Text);
 #endif
 
     summaryColor = palette.color(DPalette::TextTips);
+    backgroundBase = palette.color(QPalette::Base);
+    backgroundBase.setAlpha(100);
 }
 
 void MemoryWidget::paintEvent(QPaintEvent *e)
@@ -80,7 +83,7 @@ void MemoryWidget::paintEvent(QPaintEvent *e)
     painter.setClipPath(path);
     //背景
     QRect contentRect(rect());
-    painter.fillRect(contentRect, QBrush(QColor(255, 255, 255,100)));
+    painter.fillRect(contentRect, QBrush(backgroundBase));
 
     int sectionSize = 6;
 
@@ -120,7 +123,7 @@ void MemoryWidget::paintEvent(QPaintEvent *e)
     painter.fillPath(section, memoryColor);
 
     painter.setFont(m_memTxtFont);
-    painter.setPen(QPen(summaryColor));
+    painter.setPen(QPen(numberColor));
     painter.drawText(memTxtRect, Qt::AlignLeft | Qt::AlignVCenter, memoryContent);
 
     QRect swapTxtRect(memTxtRect.left(), memTxtRect.bottom() + margin,//+ topsize
@@ -135,7 +138,7 @@ void MemoryWidget::paintEvent(QPaintEvent *e)
     painter.fillPath(section2, swapColor);
 
     painter.setFont(m_memTxtFont);
-    painter.setPen(QPen(summaryColor));
+    painter.setPen(QPen(numberColor));
     painter.drawText(swapTxtRect, Qt::AlignLeft | Qt::AlignVCenter, swapContent);
 
     const int outsideRingRadius = (contentRect.bottom() - swapTxtRect.bottom() - topMargin) / 2;

--- a/memorymonitor/memorywidget.h
+++ b/memorymonitor/memorywidget.h
@@ -37,6 +37,7 @@ private:
     QColor swapBackgroundColor;
     QColor swapColor {"#FEDF19"};
     QColor swapForegroundColor {"#FEDF19"};
+    QColor backgroundBase {"FFFFFF"};
 
     qreal memoryBackgroundOpacity = 0.1;
     qreal memoryForegroundOpacity = 1.0;

--- a/worldclock/clockpanel.cpp
+++ b/worldclock/clockpanel.cpp
@@ -16,6 +16,7 @@
 #include <QDateTime>
 #include <QtMath>
 
+#include <DPaletteHelper>
 #include <DStyleOption>
 DWIDGET_USE_NAMESPACE
 
@@ -235,7 +236,10 @@ void ClockPanel::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event);
 
+    QColor color = DPaletteHelper::instance()->palette(this->topLevelWidget()).color(QPalette::Base);
+    color.setAlpha(100);
+
     QPainter painter(this);
-    painter.fillRect(rect(), UI::clock::panelBackground);
+    painter.fillRect(rect(), color);
 }
 }


### PR DESCRIPTION
目前亮色暗色主题下，小部件的背景颜色均固定，导致无论如何选择文字颜色都会在某个主题下难以看清。此处修改为遵循 QPalette::Base 的颜色选取小部件背景色，这与通知中心部分所采取的方案也一致。

注：关于小部件的背景颜色应当随后与设计进行讨论。

Resolve https://github.com/linuxdeepin/dde-widgets/issues/17