### PR TITLE
Revert "fix: 修复玲珑应用通知无法跳转"

### DIFF
--- a/notification/notification/bubbletool.cpp
+++ b/notification/notification/bubbletool.cpp
@@ -13,11 +13,8 @@
 #include <QX11Info>
 #include <QSettings>
 #include <QTextCodec>
-#include <QDBusConnection>
-#include <QDBusMessage>
 
 #include <DDesktopEntry>
-#include <DStandardPaths>
 
 DCORE_USE_NAMESPACE
 
@@ -191,21 +188,6 @@ const QString BubbleTool::getDeepinAppName(const QString &name)
     return desktop.localizedValue("Name", localKey, "Desktop Entry", name);
 }
 
-const QString BubbleTool::getDeepinDesktopPath(const QString &name)
-{
-    QString desktopPath;
-
-    for (const auto dataPath : DStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation)) {
-        auto path = QStringList{ dataPath, QString("%1.desktop").arg(name)}.join(QDir::separator());
-            if (QFile::exists(path)) {
-                desktopPath = path;
-                break;
-            }
-    }
-
-    return desktopPath;
-}
-
 void BubbleTool::actionInvoke(const QString &actionId, EntityPtr entity)
 {
     qDebug() << "actionId:" << actionId;
@@ -214,17 +196,10 @@ void BubbleTool::actionInvoke(const QString &actionId, EntityPtr entity)
     while (i != hints.constEnd()) {
         QStringList args = i.value().toString().split(",");
         if (!args.isEmpty()) {
-            QString appName = args.first(); //命令
-            auto desktopPath = getDeepinDesktopPath(appName);
+            QString cmd = args.first(); //命令
             args.removeFirst();
             if (i.key() == "x-deepin-action-" + actionId) {
-                QDBusConnection conn = QDBusConnection::sessionBus();
-                QDBusMessage msg = QDBusMessage::createMethodCall("org.deepin.dde.StartManager1",
-                                                        "/org/deepin/dde/StartManager1",
-                                                        "org.deepin.dde.StartManager1",
-                                                        "LaunchApp");
-                msg << desktopPath << 0 << args;
-                conn.sessionBus().call(msg, QDBus::NoBlock);
+                QProcess::startDetached(cmd, args); //执行相关命令
             }
         }
         ++i;

--- a/notification/notification/bubbletool.h
+++ b/notification/notification/bubbletool.h
@@ -25,7 +25,6 @@ public:
     static void processIconData(AppIcon *icon, EntityPtr entity); //从entity提取出图标信息设置到icon上
     static void actionInvoke(const QString &actionId, EntityPtr entity);//从entity提取出命令信息,执行命令产生相应动作
     static const QString getDeepinAppName(const QString &name);//获取应用名称
-    static const QString getDeepinDesktopPath(const QString &name);//获取desktop文件路径
 
 private:
     /*!


### PR DESCRIPTION
该提交导致了其他问题，应用名称不一定是desktop文件的前缀，
需换另一种方式实现玲珑应用响应通知的场景。