### PR TITLE
fix: Icon blur in high devicePixelRatio

### DIFF
--- a/app/instanceproxy.cpp
+++ b/app/instanceproxy.cpp
@@ -147,7 +147,6 @@ PlaceholderWidget::PlaceholderWidget(QWidget *view, QWidget *parent)
 void PlaceholderWidget::paintEvent(QPaintEvent *event)
 {
     QPixmap pixmap = m_view->grab();
-    pixmap = pixmap.scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
     QPainter painter(this);
 
     painter.setRenderHint(QPainter::Antialiasing);

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -21,6 +21,7 @@ int main(int argc, char *argv[])
 {
     // no inactive color for the application, and it need to be set before DApplication constructor.
     DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::UseInactiveColorGroup, false);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     DApplication a(argc, argv);
     a.setApplicationVersion("1.0.0");
     a.setOrganizationName("deepin");


### PR DESCRIPTION
  Missing AA_UseHighDpiPixmaps property

Issue: https://github.com/linuxdeepin/dde-widgets/issues/4