### PR TITLE
feat: Use find_program to find qdbusxml2cpp-fix

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -21,8 +21,10 @@ set(AUTOMOC_COMPILER_PREDEFINES ON)
 set(XML2CPP_DIR ${PROJECT_SOURCE_DIR}/utils/dbus/xml2cpp)
 
 #dbus xml
+find_program(QDBUSXML2CPP_FIX NAMES qdbusxml2cpp-fix REQUIRED)
+
 function(generation_dbus_interface xml class_name class_file)
-    execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/bin/qdbusxml2cpp-fix -c ${class_name} -p ${class_file} ${xml}
+    execute_process(COMMAND ${QDBUSXML2CPP_FIX} -c ${class_name} -p ${class_file} ${xml}
         WORKING_DIRECTORY ${XML2CPP_DIR})
 endfunction(generation_dbus_interface)
 

--- a/notification/CMakeLists.txt
+++ b/notification/CMakeLists.txt
@@ -19,8 +19,10 @@ set(AUTOMOC_COMPILER_PREDEFINES ON)
 set(XML2CPP_DIR ${PROJECT_SOURCE_DIR}/utils/dbus/xml2cpp)
 
 #dbus xml
+find_program(QDBUSXML2CPP_FIX NAMES qdbusxml2cpp-fix REQUIRED)
+
 function(generation_dbus_interface xml class_name class_file)
-    execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/bin/qdbusxml2cpp-fix -c ${class_name} -p ${class_file} ${xml}
+    execute_process(COMMAND ${QDBUSXML2CPP_FIX} -c ${class_name} -p ${class_file} ${xml}
         WORKING_DIRECTORY ${XML2CPP_DIR})
 endfunction(generation_dbus_interface)
 


### PR DESCRIPTION
Log: CMAKE_INSTALL_PREFIX only used for `install`, We should use find_program to find build tools