### PR TITLE
fix: widget in cell isn't center-align

### DIFF
--- a/app/widgetstore.cpp
+++ b/app/widgetstore.cpp
@@ -269,7 +269,7 @@ void WidgetStoreCell::setView(QWidget *view)
     actionAnchors->setTop(cellAnchors->top());
     actionAnchors->setRight(cellAnchors->right());
     viewAnchors->setBottom(cellAnchors->bottom());
-
+    viewAnchors->setHorizontalCenter(cellAnchors->horizontalCenter());
     setFixedSize(targetSize + (UI::Store::AddIconSize / 2));
 }
 


### PR DESCRIPTION
set viewAnchors to horizontal Center

Issue: https://github.com/linuxdeepin/dde-widgets/issues/22

Log: resolve the issue that widget in cell isn't center-align