### PR TITLE
fix: collapse button show when full collapsed

### DIFF
--- a/notification/notifycenterwidget.h
+++ b/notification/notifycenterwidget.h
@@ -43,9 +43,6 @@ private:
     void initConnections();     //初始化信号槽连接
     void refreshTheme();        //系统主题改变时,刷新主题
 
-Q_SIGNALS:
-    void notificationFoldingChanged(bool isExpand);
-
 private Q_SLOTS:
     void CompositeChanged();   //用来设置是否开启窗口特效
     void updateDisplayOfRemainingNotification();
@@ -54,10 +51,10 @@ private Q_SLOTS:
     void expandNotificationFoldingImpl(const bool refreshData);
     void collapesNotificationFolding();
     void collapesNotificationFoldingImpl(const bool refreshData);
-    void toggleNotificationFolding();
     void showSettingMenu();
     void showNotificationModuleOfControlCenter();
     void updateClearButtonVisible();
+    void updateToggleNotificationFoldingButtonVisible();
 
 private:
     inline bool hasAppNotification() const;

--- a/notification/notifymodel.cpp
+++ b/notification/notifymodel.cpp
@@ -164,6 +164,8 @@ void NotifyModel::expandDataByAppName(const QString &appName)
         const ListItemPtr &appGroup = m_notifications[i];
         if (appName.isEmpty() || appGroup->appName() == appName) {
             appGroup->toggleFolding(false);
+            m_expandedApps.insert(appName);
+            updateFullCollapsed();
         }
     }
     endResetModel();
@@ -179,12 +181,16 @@ void NotifyModel::expandData()
         appGroup->toggleFolding(true);
     }
     endResetModel();
+    m_expandedApps.clear();
+    updateFullCollapsed();
 }
 
 void NotifyModel::collapseData()
 {
     m_isCollapse = true;
     collapseDataByAppName(QString());
+    m_expandedApps.clear();
+    updateFullCollapsed();
 }
 
 void NotifyModel::collapseDataByAppName(const QString &appName)
@@ -194,6 +200,8 @@ void NotifyModel::collapseDataByAppName(const QString &appName)
         ListItemPtr &appGroup = m_notifications[i];
         if (appName.isEmpty() || appGroup->appName() == appName) {
             appGroup->toggleFolding(true);
+            m_expandedApps.remove(appName);
+            updateFullCollapsed();
         }
     }
     endResetModel();
@@ -282,6 +290,21 @@ void NotifyModel::setAppTopping(const QString &appName, bool isTopping)
 bool NotifyModel::isCollapse(const QString &appName) const
 {
     return getAppData(appName)->isCollapse();
+}
+
+bool NotifyModel::fullCollapsed() const
+{
+    return m_fullCollapsed;
+}
+
+void NotifyModel::updateFullCollapsed()
+{
+    auto value = m_isCollapse && m_expandedApps.empty();
+    if (value == m_fullCollapsed) {
+        return;
+    }
+    m_fullCollapsed = value;
+    Q_EMIT fullCollapsedChanged(value);
 }
 
 bool NotifyModel::isCollapse() const

--- a/notification/notifymodel.h
+++ b/notification/notifymodel.h
@@ -182,11 +182,14 @@ public slots:
     void setAppTopping(const QString &appName, bool isTopping);
     bool isCollapse() const;
     bool isCollapse(const QString &appName) const;
+    bool fullCollapsed() const;
+    void updateFullCollapsed();
 
 Q_SIGNALS:
     void dataChanged();                                 // 数据库有添加数据时发送该信号
     void removedNotif();                                // 删除通知完成信号
     void appCountChanged();
+    void fullCollapsedChanged(bool);
 
 private Q_SLOTS:
     void onReceivedAppInfoChanged(const QString &id, uint item, QVariant var);
@@ -209,6 +212,8 @@ private:
     QList<EntityPtr> m_cacheList;
     QTimer *m_freeTimer;
     bool m_isCollapse = true;
+    bool m_fullCollapsed = true;
+    QSet<QString> m_expandedApps;
     NotifySettingsObserver *m_settings = nullptr;
 };
 


### PR DESCRIPTION
Collapse button's state is not bound to model. Add a fullCollapsed property in model, bind collapse button's state to fullCollapsed and hasAppNotification. Do not manually show or hide it, follow model.

Log: fix collapse button show when full collapsed
Issue: https://github.com/linuxdeepin/developer-center/issues/5362