### PR TITLE
fix: Fix "undefined reference" errors

### DIFF
--- a/memorymonitor/CMakeLists.txt
+++ b/memorymonitor/CMakeLists.txt
@@ -19,7 +19,7 @@ set(AUTOMOC_COMPILER_PREDEFINES ON)
 include(src.cmake)
 
 SET(LIBRARY_OUTPUT_PATH ../app/plugins)
-add_library(${PROJECT_NAME} SHARED plugin.h plugin.cpp ${SOURCES} ${HEADERS})
+add_library(${PROJECT_NAME} MODULE plugin.h plugin.cpp ${SOURCES} ${HEADERS})
 
 set(COMMON_LIBS
     Qt5::Core
@@ -29,9 +29,9 @@ set(COMMON_LIBS
     ${DtkWidget_LIBRARIES}
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC ${COMMON_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${COMMON_LIBS})
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}
     ${DtkWidget_INCLUDE_DIRS}

--- a/notification/CMakeLists.txt
+++ b/notification/CMakeLists.txt
@@ -37,7 +37,7 @@ file(GLOB DBUS_INTERFACES "utils/dbus/xml2cpp/*.*")
 include(src.cmake)
 
 SET(LIBRARY_OUTPUT_PATH ../app/plugins)
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME} MODULE
     plugin.h
     plugin.cpp
     ${SOURCES}
@@ -58,9 +58,9 @@ set(COMMON_LIBS
     ${DtkWidget_LIBRARIES}
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC ${COMMON_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${COMMON_LIBS})
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME} PRIVATE
     Qt5::Concurrent
     Qt5::Svg
     Qt5::X11Extras

--- a/worldclock/CMakeLists.txt
+++ b/worldclock/CMakeLists.txt
@@ -19,7 +19,7 @@ set(AUTOMOC_COMPILER_PREDEFINES ON)
 include(src.cmake)
 
 SET(LIBRARY_OUTPUT_PATH ../app/plugins)
-add_library(${PROJECT_NAME} SHARED plugin.h plugin.cpp ${SOURCES} ${HEADERS} qrc/datetime.qrc)
+add_library(${PROJECT_NAME} MODULE plugin.h plugin.cpp ${SOURCES} ${HEADERS} qrc/datetime.qrc)
 
 set(COMMON_LIBS
     Qt5::Core
@@ -29,9 +29,9 @@ set(COMMON_LIBS
     ${DtkWidget_LIBRARIES}
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC ${COMMON_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${COMMON_LIBS})
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}
     ${DtkWidget_INCLUDE_DIRS}


### PR DESCRIPTION
Build failure with -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--no-undefined" argument

Log: Plugins should be set as "add_library(... MODULE ...)". And plugins may not be linked by other targets, so should set them as PRIVATE instead of PUBLIC.