### PR TITLE
fix: does not acquire focus after shown

### DIFF
--- a/app/mainview.cpp
+++ b/app/mainview.cpp
@@ -14,6 +14,8 @@
 #include <QDebug>
 #include <QHBoxLayout>
 #include <QScrollArea>
+#include <QApplication>
+#include <QWindow>
 #include <DFontManager>
 #include <DPlatformWindowHandle>
 DGUI_USE_NAMESPACE
@@ -100,6 +102,11 @@ void MainView::init()
 
     connect(m_animationContainer, &AnimationViewContainer::outsideAreaReleased, this, &MainView::hideView);
     QObject::connect(m_geometryHandler, &GeometryHandler::geometryChanged, this, &MainView::refreshShownView);
+    connect(qApp, &QApplication::focusWindowChanged, this, [this](QWindow *focus){
+        if (!focus) {
+            hideView();
+        }
+    });
 }
 
 MainView::Mode MainView::displayMode() const

--- a/app/utils/animationviewcontainer.cpp
+++ b/app/utils/animationviewcontainer.cpp
@@ -89,6 +89,7 @@ void AnimationViewContainer::showView()
     const auto &rect = m_targetRect;
     qDebug(dwLog()) << "show view:" << rect;
     show();
+    activateWindow();
 
     registerRegion();
     m_currentXAni->setStartValue(rect.left());


### PR DESCRIPTION
 * Activate window as soon as main view is shown.
 * Hide main view when application loses focus.

Related-Issue: https://github.com/linuxdeepin/developer-center/issues/6483
Log: fix does not acquire focus after shown
