### PR TITLE
chore: bump version to 6.0.21

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-widgets (6.0.21) unstable; urgency=medium
+
+  * fix: add/delete button size tweak(https://github.com/linuxdeepin/developer-center/issues/7552)
+  * fix: chore: do not hide in debug mode
+  * fix: fix: border tearing due to scaling(Issue: https://github.com/linuxdeepin/developer-center/issues/5550)
+  * fix:  Notification center widget swap memory display 'nan'(Issue: Issue: https://github.com/linuxdeepin/developer-center/issues/7400)
+
+ -- Zhang kun <zhangkun2@uniontech.com>  Wed, 10 Apr 2024 09:59:47 +0800
+
 dde-widgets (6.0.20) unstable; urgency=medium
 
   * fix: scroll bar covers the content(Issue: https://github.com/linuxdeepin/developer-center/issues/6744)


### PR DESCRIPTION
* fix: add/delete button size tweak(Issue: https://github.com/linuxdeepin/developer-center/issues/7552)
* fix: chore: do not hide in debug mode
* fix: fix: border tearing due to scaling(Issue: https://github.com/linuxdeepin/developer-center/issues/5550)
* fix:  Notification center widget swap memory display 'nan'(Issue: Issue: https://github.com/linuxdeepin/developer-center/issues/7400)